### PR TITLE
Fixed typo in router unregister method

### DIFF
--- a/site/src/router.js
+++ b/site/src/router.js
@@ -33,7 +33,7 @@ class Router {
   }
 
   unregister(path) {
-    this.registeredRoute.delete(path);
+    this.registeredRoutes.delete(path);
   }
 
   get location() {


### PR DESCRIPTION
 unregister() in site/src/router.js referenced 'this.registerRoute', which wasn't defined. this.registeredRoutes was defined in the constructor, and used correctly everywhere else. This caused unregister() to throw a TypeError instead of removing the route.

Fixes #36